### PR TITLE
Quote services

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -9,7 +9,7 @@ services:
         arguments: [%zendesk_api_key%, %zendesk_api_user%, %zendesk_api_subdomain%]
     zendesk.repos:
         class: %zendesk.repositoryservice.class%
-        arguments: [@zendesk.api]
+        arguments: ['@zendesk.api']
     zendesk.service:
         class: %zendesk.zendeskservice.class%
-        arguments: [@zendesk.repos]
+        arguments: ['@zendesk.repos']


### PR DESCRIPTION
Fix bug on Symfony 3.X:
```
  In YamlFileLoader.php line 663:                                                  
                                                                                   
    The file "/vagrant/vendor/malwarebytes/zendeskbundle/Malwarebytes/ZendeskBu    
    ndle/DependencyInjection/../Resources/config/services.yml" does not contain    
     valid YAML: The reserved indicator "@" cannot start a plain scalar; you ne    
    ed to quote the scalar at line 12 (near "arguments: [@zendesk.api]"). 
```
